### PR TITLE
Fix snapshot.R OOM on GHA runner: chunked pulls + dir output

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,8 +1,8 @@
 name: Monthly realtime snapshot
 
 # Pull ~18 mo of BC realtime water-temp data from ECCC via tidyhydat /
-# ngr::ngr_hyd_realtime and write a partitioned parquet snapshot to
-# s3://water-temp-bc/data/realtime/<yyyy>/<mm>/snapshot_<yyyy-mm-dd>.parquet.
+# ngr::ngr_hyd_realtime and write a partitioned chunked parquet snapshot to
+# s3://water-temp-bc/data/realtime/<yyyy>/<mm>/snapshot_<yyyy-mm-dd>/chunk_NNN.parquet.
 #
 # Authenticates via OIDC against role_gha_water_temp_bc, provisioned by
 # NewGraphEnvironment/rtj#147. Trust is scoped to main branch only.
@@ -46,21 +46,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          shopt -s globstar nullglob
-          files=(data/realtime/**/snapshot_*.parquet)
-          if [ ${#files[@]} -eq 0 ]; then
-            echo "No snapshot file produced under data/realtime/" >&2
+          # snapshot.R writes data/realtime/<yyyy>/<mm>/snapshot_<yyyy-mm-dd>/
+          # as a directory of chunk_NNN.parquet files. find -type d narrows to
+          # directories so a stray file under data/realtime/ can't fool us.
+          mapfile -t dirs < <(find data/realtime -mindepth 3 -maxdepth 3 -type d -name 'snapshot_*')
+          if [ ${#dirs[@]} -eq 0 ]; then
+            echo "No snapshot directory produced under data/realtime/" >&2
             exit 1
           fi
-          if [ ${#files[@]} -gt 1 ]; then
-            echo "Multiple snapshot files found; expected exactly one:" >&2
-            printf '  %s\n' "${files[@]}" >&2
+          if [ ${#dirs[@]} -gt 1 ]; then
+            echo "Multiple snapshot directories found; expected exactly one:" >&2
+            printf '  %s\n' "${dirs[@]}" >&2
             exit 1
           fi
-          FILE="${files[0]}"
-          DEST="s3://water-temp-bc/${FILE}"
-          echo "Uploading ${FILE} -> ${DEST}"
-          aws s3 cp "$FILE" "$DEST"
+          DIR="${dirs[0]}"
+          DEST="s3://water-temp-bc/${DIR}/"
+          echo "Syncing ${DIR}/ -> ${DEST} (--delete removes any orphan chunks from a prior same-day run) ..."
+          aws s3 sync --delete "$DIR" "$DEST"
 
       - name: Session info
         if: always()

--- a/scripts/snapshot.R
+++ b/scripts/snapshot.R
@@ -3,16 +3,17 @@
 #
 # Pull ~18 months of BC realtime water-temp (and associated parameters) from
 # the ECCC realtime service via tidyhydat / ngr::ngr_hyd_realtime and write a
-# single point-in-time snapshot parquet to:
+# single point-in-time snapshot as a directory of chunked parquets at:
 #
-#   data/realtime/<yyyy>/<mm>/snapshot_<yyyy-mm-dd>.parquet
+#   data/realtime/<yyyy>/<mm>/snapshot_<yyyy-mm-dd>/chunk_NNN.parquet
 #
 # A `harvested_at` column is added to every row so the read-time dedup pattern
-# (slice_max(harvested_at) by STATION_NUMBER + Parameter + Date) can let newer
+# (slice_max(harvested_at) by STATION_NUMBER + Parameter + Date) lets newer
 # QC'd values win over earlier provisional ones.
 #
-# Designed to run unattended in .github/workflows/snapshot.yml on the 1st of
-# each month, and identically when run locally.
+# Stations are pulled in chunks so peak R memory stays well under the 7 GB
+# GHA runner ceiling. Each chunk is written + freed before the next starts.
+# Readers don't care about chunking; arrow::open_dataset() walks the tree.
 
 suppressPackageStartupMessages({
   library(dplyr)
@@ -40,48 +41,77 @@ stations_eccc <- if (fs::file_exists(eccc_xlsx)) {
 stations <- unique(c(stations_tidyhydat, stations_eccc))
 message("Pulling realtime data for ", length(stations), " stations...")
 
-# --- Pull --------------------------------------------------------------------
-# Pin days_back so the snapshot window doesn't drift if ngr changes its default.
+# --- Pull + write in chunks --------------------------------------------------
 # 581 = current ngr default and the practical max ECCC realtime serves (~19mo).
-DAYS_BACK <- 581
+# Pinned so the window doesn't drift if ngr changes its default.
+DAYS_BACK  <- 581
+
+# Chunk size keeps peak R memory bounded — accumulating all ~290 stations
+# before bind_rows OOM-killed the 7 GB GHA runner in run 25880907973.
+CHUNK_SIZE <- 50
 
 # Wrap with possibly() so a single station erroring (network blip, station
-# temporarily missing, API change) does not abort the whole monthly snapshot —
-# it just contributes NULL like a station with no realtime feed.
+# temporarily missing, API change) does not abort the whole monthly snapshot.
 pull_station <- purrr::possibly(
   function(id) ngr::ngr_hyd_realtime(id, days_back = DAYS_BACK),
   otherwise = NULL
 )
 
-dat <- stations |>
-  purrr::map(pull_station) |>
-  purrr::discard(is.null) |>
-  dplyr::bind_rows() |>
-  ngr::ngr_tidy_cols_rm_na() |>
-  dplyr::mutate(harvested_at = now)
-
-if (nrow(dat) == 0) {
-  stop("Snapshot produced 0 rows — refusing to write an empty parquet. ",
-       "Investigate before the next monthly run.")
-}
-stopifnot("Date column missing from pulled data" = "Date" %in% names(dat))
-
-# --- Write -------------------------------------------------------------------
-yr  <- format(today, "%Y")
-mo  <- format(today, "%m")
-out_dir  <- fs::path("data", "realtime", yr, mo)
-out_file <- fs::path(out_dir, paste0("snapshot_", today, ".parquet"))
+yr      <- format(today, "%Y")
+mo      <- format(today, "%m")
+out_dir <- fs::path("data", "realtime", yr, mo, paste0("snapshot_", today))
+# Clean any leftovers from a prior same-day run; otherwise stale chunks
+# would mix with new ones and the reader would double-count rows.
+if (fs::dir_exists(out_dir)) fs::dir_delete(out_dir)
 fs::dir_create(out_dir, recurse = TRUE)
 
-arrow::write_parquet(dat, out_file)
+chunks   <- split(stations, ceiling(seq_along(stations) / CHUNK_SIZE))
+n_chunks <- length(chunks)
 
-# --- Summary -----------------------------------------------------------------
-date_min <- suppressWarnings(min(dat$Date, na.rm = TRUE))
-date_max <- suppressWarnings(max(dat$Date, na.rm = TRUE))
+for (i in seq_along(chunks)) {
+  message("Chunk ", i, "/", n_chunks, " (", length(chunks[[i]]), " stations)")
+  dat <- chunks[[i]] |>
+    purrr::map(pull_station) |>
+    purrr::discard(is.null) |>
+    dplyr::bind_rows() |>
+    dplyr::mutate(harvested_at = now)
+
+  if (nrow(dat) > 0) {
+    out_file <- fs::path(out_dir, sprintf("chunk_%03d.parquet", i))
+    arrow::write_parquet(dat, out_file)
+    message("  wrote ", out_file, " — ", format(nrow(dat), big.mark = ","), " rows")
+  } else {
+    message("  no data in this chunk")
+  }
+
+  rm(dat); gc(verbose = FALSE)
+}
+
+# --- Verify + summary --------------------------------------------------------
+written <- fs::dir_ls(out_dir, glob = "*.parquet")
+if (length(written) == 0) {
+  stop("Snapshot produced 0 chunks — refusing to leave an empty snapshot dir. ",
+       "Investigate before the next monthly run.")
+}
+
+ds <- arrow::open_dataset(out_dir)
+stopifnot("Date column missing from snapshot" = "Date" %in% ds$schema$names)
+
+summary_row <- ds |>
+  dplyr::summarise(
+    rows     = dplyr::n(),
+    stations = dplyr::n_distinct(STATION_NUMBER),
+    min_date = min(Date, na.rm = TRUE),
+    max_date = max(Date, na.rm = TRUE)
+  ) |>
+  dplyr::collect()
+
 message(
-  "Wrote ", out_file, "\n",
-  "  rows:              ", format(nrow(dat), big.mark = ","), "\n",
-  "  distinct stations: ", dplyr::n_distinct(dat$STATION_NUMBER), "\n",
-  "  date range:        ", format(date_min), " -> ", format(date_max), "\n",
+  "Snapshot complete: ", out_dir, "\n",
+  "  chunks:            ", length(written), "\n",
+  "  rows:              ", format(summary_row$rows, big.mark = ","), "\n",
+  "  distinct stations: ", summary_row$stations, "\n",
+  "  date range:        ", format(summary_row$min_date), " -> ",
+                            format(summary_row$max_date), "\n",
   "  harvested_at:      ", format(now)
 )


### PR DESCRIPTION
## Summary

The Phase 4 workflow OOM-killed on the ubuntu-latest runner (7 GB RAM) at the `bind_rows` step on ~290 accumulated station tibbles (run [25880907973](https://github.com/NewGraphEnvironment/water-temp-bc/actions/runs/25880907973), ~41 min in). Local laptop with 32 GB had no problem.

Fix: pull stations in chunks of 50; bind/write/discard each chunk so peak memory stays bounded. Output shape changes from a single `snapshot_<yyyy-mm-dd>.parquet` file to a directory of `chunk_NNN.parquet` files at the same logical location. Readers don't change — `arrow::open_dataset()` already walks the tree, so `query_canonical()` works transparently.

Collateral cleanups:
- Drop `ngr::ngr_tidy_cols_rm_na()` — was stripping all-NA columns inconsistently across snapshots; keeping all columns improves cross-snapshot schema stability.
- Clean `out_dir` at start so a same-day re-run doesn't mix stale chunks with new ones.
- End-of-run verification reads back via `arrow::open_dataset()` and asserts `Date` column present.
- Workflow upload step: `find -type d -name 'snapshot_*'` (instead of glob, so a stray file can't trip the guard) and `aws s3 sync --delete` (instead of `cp --recursive`, so orphan chunks from a prior same-day run get removed from S3).

The stale single-file `s3://water-temp-bc/data/realtime/2026/05/snapshot_2026-05-14.parquet` from the Phase 2 manual upload was deleted out-of-band (bucket versioning preserves prior copy).

## Related

- Fix for water-temp-bc#17 Phase 4 verification (the original PR #18 landed the workflow; this lands the runner-memory fix).

## Test plan

- [x] `/code-check` clean (2 rounds; R1 fixed 3, accepted 2; R2 clean)
- [ ] After merge: re-trigger `workflow_dispatch` on main; verify chunked snapshot lands at `s3://water-temp-bc/data/realtime/2026/05/snapshot_<date>/` and `query_canonical()` reads it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)